### PR TITLE
Hotfix/uncaught error on no fields

### DIFF
--- a/connectMeteorRedux.js
+++ b/connectMeteorRedux.js
@@ -131,7 +131,8 @@ const initMeteorRedux = (preloadedState = undefined, enhancer = undefined) => {
                 MeteorStore.dispatch({type: 'CHANGED', collection, id, fields});
             });
             Meteor.ddp.on('added', async (obj) => {
-                const {collection, id, fields} = obj;
+                const {collection, id} = obj;
+                const fields = obj.fields || {};
                 fields._id = id;
                 const getCollection = MeteorStore.getState()[collection];
                 if(

--- a/connectMeteorRedux.js
+++ b/connectMeteorRedux.js
@@ -121,12 +121,14 @@ const initMeteorRedux = (preloadedState = undefined, enhancer = undefined) => {
         });
         if (connected) {
             Meteor.ddp.on('removed', async (obj) => {
-                const {collection, id, fields} = obj;
+                const {collection, id} = obj;
+                const fields = obj.fields || {};
                 await nextFrame();
                 MeteorStore.dispatch({type: 'REMOVED', collection, id, fields});
             });
             Meteor.ddp.on('changed', async (obj) => {
-                const {collection, id, fields} = obj;
+                const {collection, id} = obj;
+                const fields = obj.fields || {};
                 await nextFrame();
                 MeteorStore.dispatch({type: 'CHANGED', collection, id, fields});
             });


### PR DESCRIPTION
I've had a situation that I needed nothing but `_id` fields in my subscription. In such cases I had `[TypeError: undefined is not an object (evaluating 'fields._id=id')]`, since `fields` was undefined if there were no fields except `_id`. Initializing fields to an empty object instead of undefined fixed that for me.