### PR TITLE
flip connected flag on connected

### DIFF
--- a/connectMeteorRedux.js
+++ b/connectMeteorRedux.js
@@ -117,6 +117,9 @@ const initMeteorRedux = (preloadedState = undefined, enhancer = undefined) => {
         Meteor.ddp.on('disconnected', () => {
             connected = false;
         });
+        Meteor.ddp.on('connected', () => {
+            connected = true;
+        });
         if (connected) {
             Meteor.ddp.on('removed', async (obj) => {
                 const {collection, id} = obj;


### PR DESCRIPTION
I've spotted that `connected` is set to `false` on disconnect but is not restored to `true` on connect. Is that on purpose? If yes, plz explain, what's the trick, if it's really is a mistake, you can merge this.