### PR TITLE
Add cleanup method

### DIFF
--- a/connectMeteorRedux.js
+++ b/connectMeteorRedux.js
@@ -1,5 +1,6 @@
 /**
  * Created by Julian on 12/30/16.
+ * Edited by Jaakko on 08/28/18.
  */
 import Meteor, { getData } from 'react-native-meteor';
 import { createStore, combineReducers } from 'redux';
@@ -96,7 +97,7 @@ const initMeteorRedux = (
   const newReducers = customReducers !== undefined
     ? combineReducers({ ...customReducers, meteorReduxReducers })
     : meteorReduxReducers;
-  const MeteorStore = createStore(newReducers, preloadedState, enhancer);
+  const MeteorStore = createStore(newReducers, window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(), preloadedState, enhancer);
 
   MeteorStore.loaded = () => {
     meteorReduxEmitter.emit('rehydrated');
@@ -198,7 +199,7 @@ class MeteorOffline {
     if (!options.store) {
       this.store = initMeteorRedux(undefined, autoRehydrate());
     }
-    this.persister = persistStore(
+    this.persistor = persistStore(
       this.store,
       {
         storage: AsyncStorage,
@@ -231,6 +232,12 @@ class MeteorOffline {
     }
     const { userId } = this.store.getState();
     return Meteor.collection('users').findOne(userId);
+  }
+
+  reset() {
+    this.store.dispatch({ type: 'HARDRESET' });
+    this.persistor.purge();
+    console.log('performed meteor offline hard reset');
   }
 
   subscribe(uniqueName, name, ...params) {

--- a/connectMeteorRedux.js
+++ b/connectMeteorRedux.js
@@ -5,6 +5,7 @@ import Meteor, { getData } from 'react-native-meteor';
 import { createStore, combineReducers } from 'redux';
 import { AsyncStorage } from 'react-native';
 import _ from 'lodash';
+import traverse from 'traverse';
 import EventEmitter from 'events';
 import { persistStore, autoRehydrate } from 'redux-persist';
 

--- a/connectMeteorRedux.js
+++ b/connectMeteorRedux.js
@@ -188,6 +188,15 @@ const returnCached = (cursor, store, collection, doDisable) => {
   return cursor;
 };
 
+const dateTransform = createTransform(null, (outboundState) => {
+    return traverse(outboundState).map((val) => {
+        if (Time.isISOStringDate(val)) {
+            return new Date(val);
+        }
+        return val;
+    });
+});
+
 class MeteorOffline {
   constructor(options = {}) {
     this.offline = true;
@@ -204,6 +213,7 @@ class MeteorOffline {
         storage: AsyncStorage,
         debounce: options.debounce || 1000,
         blacklist: ['reactNativeMeteorOfflineRecentlyAdded'],
+        transforms: [dateTransform],
       },
       () => {
         this.store.loaded();

--- a/connectMeteorRedux.js
+++ b/connectMeteorRedux.js
@@ -1,6 +1,5 @@
 /**
  * Created by Julian on 12/30/16.
- * Edited by Jaakko on 08/28/18.
  */
 import Meteor, { getData } from 'react-native-meteor';
 import { createStore, combineReducers } from 'redux';

--- a/connectMeteorRedux.js
+++ b/connectMeteorRedux.js
@@ -5,8 +5,6 @@ import Meteor, { getData } from 'react-native-meteor';
 import { createStore, combineReducers } from 'redux';
 import { AsyncStorage } from 'react-native';
 import _ from 'lodash';
-import traverse from 'traverse';
-import moment from 'moment';
 import EventEmitter from 'events';
 import { persistStore, autoRehydrate, createTransform } from 'redux-persist';
 
@@ -196,15 +194,6 @@ const returnCached = (cursor, store, collection, doDisable) => {
   return cursor;
 };
 
-const dateTransform = createTransform(null, (outboundState) => {
-    return traverse(outboundState).map((val) => {
-        if (moment(val, 'YYYY-MM-DD', false).isValid()) {
-          return new Date(val);
-        }
-        return val;
-    });
-});
-
 class MeteorOffline {
   constructor(options = {}) {
     this.offline = true;
@@ -221,7 +210,6 @@ class MeteorOffline {
         storage: AsyncStorage,
         debounce: options.debounce || 1000,
         blacklist: ['reactNativeMeteorOfflineRecentlyAdded'],
-        transforms: [dateTransform],
       },
       () => {
         this.store.loaded();

--- a/connectMeteorRedux.js
+++ b/connectMeteorRedux.js
@@ -88,6 +88,7 @@ const meteorReduxReducers = (
 const meteorReduxEmitter = new EventEmitter();
 
 const initMeteorRedux = (
+  customDebugger = undefined,
   preloadedState = undefined,
   enhancer = undefined,
   customReducers = undefined
@@ -96,7 +97,12 @@ const initMeteorRedux = (
   const newReducers = customReducers !== undefined
     ? combineReducers({ ...customReducers, meteorReduxReducers })
     : meteorReduxReducers;
-  const MeteorStore = createStore(newReducers, preloadedState, enhancer);
+  const MeteorStore = createStore(
+    newReducers,
+    customDebugger,
+    preloadedState,
+    enhancer
+  );
 
   MeteorStore.loaded = () => {
     meteorReduxEmitter.emit('rehydrated');
@@ -205,7 +211,7 @@ class MeteorOffline {
     this.subscriptions = [];
     this.collections = [];
     if (!options.store) {
-      this.store = initMeteorRedux(undefined, autoRehydrate());
+      this.store = initMeteorRedux(options.debugger || undefined, undefined, autoRehydrate());
     }
     this.persistor = persistStore(
       this.store,

--- a/connectMeteorRedux.js
+++ b/connectMeteorRedux.js
@@ -6,6 +6,7 @@ import { createStore, combineReducers } from 'redux';
 import { AsyncStorage } from 'react-native';
 import _ from 'lodash';
 import traverse from 'traverse';
+import moment from 'moment';
 import EventEmitter from 'events';
 import { persistStore, autoRehydrate, createTransform } from 'redux-persist';
 
@@ -198,8 +199,8 @@ const returnCached = (cursor, store, collection, doDisable) => {
 const dateTransform = createTransform(null, (outboundState) => {
     return traverse(outboundState).map((val) => {
         console.log(val);
-        if (typeof(val) == 'string' && Date.parse(val) !== NaN) {
-            return new Date(val);
+        if (moment(val).isValid()) {
+          return new Date(val);
         }
         return val;
     });

--- a/connectMeteorRedux.js
+++ b/connectMeteorRedux.js
@@ -7,7 +7,7 @@ import { AsyncStorage } from 'react-native';
 import _ from 'lodash';
 import traverse from 'traverse';
 import EventEmitter from 'events';
-import { persistStore, autoRehydrate } from 'redux-persist';
+import { persistStore, autoRehydrate, createTransform } from 'redux-persist';
 
 const meteorReduxReducers = (
   state = { reactNativeMeteorOfflineRecentlyAdded: [] },
@@ -197,7 +197,8 @@ const returnCached = (cursor, store, collection, doDisable) => {
 
 const dateTransform = createTransform(null, (outboundState) => {
     return traverse(outboundState).map((val) => {
-        if (Time.isISOStringDate(val)) {
+        console.log(val);
+        if (typeof(val) == 'string' && Date.parse(val) !== NaN) {
             return new Date(val);
         }
         return val;

--- a/connectMeteorRedux.js
+++ b/connectMeteorRedux.js
@@ -96,7 +96,7 @@ const initMeteorRedux = (
   const newReducers = customReducers !== undefined
     ? combineReducers({ ...customReducers, meteorReduxReducers })
     : meteorReduxReducers;
-  const MeteorStore = createStore(newReducers, window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(), preloadedState, enhancer);
+  const MeteorStore = createStore(newReducers, preloadedState, enhancer);
 
   MeteorStore.loaded = () => {
     meteorReduxEmitter.emit('rehydrated');

--- a/connectMeteorRedux.js
+++ b/connectMeteorRedux.js
@@ -198,8 +198,7 @@ const returnCached = (cursor, store, collection, doDisable) => {
 
 const dateTransform = createTransform(null, (outboundState) => {
     return traverse(outboundState).map((val) => {
-        console.log(val);
-        if (moment(val).isValid()) {
+        if (moment(val, 'YYYY-MM-DD', false).isValid()) {
           return new Date(val);
         }
         return val;
@@ -255,7 +254,7 @@ class MeteorOffline {
   reset() {
     this.store.dispatch({ type: 'HARDRESET' });
     this.persistor.purge();
-    console.log('performed meteor offline hard reset');
+    //console.log('performed meteor offline hard reset');
   }
 
   subscribe(uniqueName, name, ...params) {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-native-meteor": "^1.0.3",
     "redux": "^3.6.0",
     "redux-persist": "^4.0.1",
-    "events": "^1.1.1"
+    "events": "^1.1.1",
+    "traverse": "0.6.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "redux": "^3.6.0",
     "redux-persist": "^4.0.1",
     "events": "^1.1.1",
-    "traverse": "^0.6.6"
+    "traverse": "^0.6.6",
+    "moment": "^2.22.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,5 @@
     "redux": "^3.6.0",
     "redux-persist": "^4.0.1",
     "events": "^1.1.1",
-    "traverse": "^0.6.6",
-    "moment": "^2.22.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "redux": "^3.6.0",
     "redux-persist": "^4.0.1",
     "events": "^1.1.1",
-    "traverse": "0.6.6"
+    "traverse": "^0.6.6"
   }
 }


### PR DESCRIPTION
As discussed in #51, sometimes it is necessary to be able to cleanup the redux store state as well as its persistor. To achieve this, I simply added a reset function to the MeteorOffline component. This both resets the state and purges the persistor. I also renamed persister to persistor as persistor seems to be the common name used (confused me while reading the code).

https://github.com/DesignmanIO/react-native-meteor-offline/issues/51