### PR TITLE
Fixes #58 by changing object based _.omit to array based _.without

### DIFF
--- a/connectMeteorRedux.js
+++ b/connectMeteorRedux.js
@@ -60,9 +60,9 @@ const meteorReduxReducers = (
     case 'REMOVE_AFTER_RECONNECT':
       // todo: check for removed docs
       const { removed } = action;
-      const withoutRemoved = _.omit(
+      const withoutRemoved = _.without(
         state.reactNativeMeteorOfflineRecentlyAdded,
-        removed
+        ...removed
       );
       if (getData().db[collection]) getData().db[collection].remove({ _id: { $in: removed } });
       return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-meteor-redux",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "Link react-native-meteor to redux",
   "main": "connectMeteorRedux.js",
   "scripts": {


### PR DESCRIPTION
Based on https://github.com/DesignmanIO/react-native-meteor-offline/issues/58#issuecomment-464847521 I think the lodash `omit` method call was transforming the `reactNativeMeteorOfflineRecentlyAdded` array into an key-value object and causing a `invalid attempt to spread non-iterable instance` issue.

This PR should fix that!